### PR TITLE
Allow use class without explicit alias

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -214,7 +214,7 @@ class Printer extends Standard
     {
         foreach ($node->uses as $use) {
             if ($node->type === Stmt\Use_::TYPE_NORMAL) {
-                $this->securityManager->addClassAlias((string)$use->name, (string)($use->alias ?? $use->name));
+                $this->securityManager->addClassAlias((string)$use->name, $use->alias !== null ? (string)$use->alias : null);
             }
             elseif ($node->type === Stmt\Use_::TYPE_FUNCTION) {
                 $this->securityManager->addFunctionAlias((string)$use->name, (string)($use->alias ?? $use->name));
@@ -228,7 +228,7 @@ class Printer extends Standard
     {
         foreach ($node->uses as $use) {
             if ($node->type === Stmt\Use_::TYPE_NORMAL) {
-                $this->securityManager->addClassAlias((string)$use->name, (string)($use->alias ?? $use->name));
+                $this->securityManager->addClassAlias((string)$use->name, $use->alias !== null ? (string)$use->alias : null);
             }
             elseif ($node->type === Stmt\Use_::TYPE_FUNCTION) {
                 $this->securityManager->addFunctionAlias((string)$use->name, (string)($use->alias ?? $use->name));

--- a/src/SecurityManager.php
+++ b/src/SecurityManager.php
@@ -555,8 +555,13 @@ class SecurityManager
         $this->functionAliases[$alias] = $function;
     }
 
-    public function addClassAlias(string $class, string $alias): void
+    public function addClassAlias(string $class, ?string $alias): void
     {
+        if ($alias === null) {
+            $parts = \explode('\\', \ltrim($class, '\\'));
+            $alias = $parts[\array_key_last($parts)];
+        }
+
         $this->classAliases[$alias] = $class;
     }
 

--- a/tests/safe/015.phpt
+++ b/tests/safe/015.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test use allowed class
+--FILE--
+<?php
+
+use PSX\Sandbox\Tests\FooService;
+
+new FooService();
+
+return 1;
+
+--EXPECT--
+1
+--OPTIONS--
+{"allowedClasses": ["PSX\\Sandbox\\Tests\\FooService"]}

--- a/tests/safe/016.phpt
+++ b/tests/safe/016.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test use with alias allowed class
+--FILE--
+<?php
+
+use PSX\Sandbox\Tests\FooService as FooService1;
+
+new FooService1();
+
+return 1;
+
+--EXPECT--
+1
+--OPTIONS--
+{"allowedClasses": ["PSX\\Sandbox\\Tests\\FooService"]}

--- a/tests/safe/017.phpt
+++ b/tests/safe/017.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test use allowed class from global namespace
+--FILE--
+<?php
+
+namespace foo;
+
+use \DateTimeImmutable;
+
+new DateTimeImmutable( 'now' );
+
+return 1;
+
+--EXPECT--
+1

--- a/tests/unsafe/043.phpt
+++ b/tests/unsafe/043.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test use with NOT allowed class
+--FILE--
+<?php
+
+use PSX\Sandbox\Tests\FooService;
+
+new FooService();
+
+return 1;
+
+--EXPECT--
+1

--- a/tests/unsafe/044.phpt
+++ b/tests/unsafe/044.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test use with alias NOT allowed class
+--FILE--
+<?php
+
+use PSX\Sandbox\Tests\FooService as FooService1;
+
+new FooService1();
+
+return 1;
+
+--EXPECT--
+1

--- a/tests/unsafe/045.phpt
+++ b/tests/unsafe/045.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test use with NOT allowed class from global namespace
+--FILE--
+<?php
+
+use \Reflection;
+
+new Reflection();
+
+return 1;
+
+--EXPECT--
+1


### PR DESCRIPTION
Hi,

I fixed an oversight I made when I added the use class / aliases checks

before ( if the class is in the allowed classes list ) `use` without an alias would not work
```PHP
<?php

use PSX\Sandbox\Tests\FooService;

new FooService();
````
and would have to be written like this:
```PHP
<?php

use PSX\Sandbox\Tests\FooService as FooService;

new FooService();
````